### PR TITLE
Fix loads of deprecations with recent compilers

### DIFF
--- a/source/windows/dbt.d
+++ b/source/windows/dbt.d
@@ -111,7 +111,7 @@ struct DEV_BROADCAST_PORT_A {
 	DWORD dbcp_devicetype;
 	DWORD dbcp_reserved;
 	char  _dbcp_name;
-	char* dbcp_name() { return &_dbcp_name; }
+	char* dbcp_name() return scope { return &_dbcp_name; }
 }
 alias DEV_BROADCAST_PORT_A* PDEV_BROADCAST_PORT_A;
 
@@ -120,14 +120,14 @@ struct DEV_BROADCAST_PORT_W {
 	DWORD  dbcp_devicetype;
 	DWORD  dbcp_reserved;
 	WCHAR  _dbcp_name;
-	WCHAR* dbcp_name() { return &_dbcp_name; }
+	WCHAR* dbcp_name() return scope { return &_dbcp_name; }
 }
 alias DEV_BROADCAST_PORT_W* PDEV_BROADCAST_PORT_W;
 
 struct DEV_BROADCAST_USERDEFINED {
 	DEV_BROADCAST_HDR dbud_dbh;
 	char  _dbud_szName;
-	char* dbud_szName() { return &_dbud_szName; }
+	char* dbud_szName() return scope { return &_dbud_szName; }
 }
 
 struct DEV_BROADCAST_VOLUME {
@@ -153,7 +153,7 @@ static if (_WIN32_WINNT >= 0x500) {
 		DWORD dbcc_reserved;
 		GUID  dbcc_classguid;
 		char  _dbcc_name;
-		char* dbcc_name() { return &_dbcc_name; }
+		char* dbcc_name() return scope { return &_dbcc_name; }
 	}
 	alias DEV_BROADCAST_DEVICEINTERFACE_A* PDEV_BROADCAST_DEVICEINTERFACE_A;
 
@@ -163,7 +163,7 @@ static if (_WIN32_WINNT >= 0x500) {
 		DWORD  dbcc_reserved;
 		GUID   dbcc_classguid;
 		WCHAR  _dbcc_name;
-		WCHAR* dbcc_name() { return &_dbcc_name; }
+		WCHAR* dbcc_name() return scope { return &_dbcc_name; }
 	}
 	alias DEV_BROADCAST_DEVICEINTERFACE_W* PDEV_BROADCAST_DEVICEINTERFACE_W;
 
@@ -183,7 +183,7 @@ static if (_WIN32_WINNT >= 0x500) {
 		GUID   dbch_eventguid;
 		LONG   dbch_nameoffset;
 		BYTE   _dbch_data;
-		BYTE*  dbch_data() { return &_dbch_data; }
+		BYTE*  dbch_data() return scope { return &_dbch_data; }
 	}
 	alias DEV_BROADCAST_HANDLE* PDEV_BROADCAST_HANDLE;
 }

--- a/source/windows/dbt.d
+++ b/source/windows/dbt.d
@@ -183,7 +183,7 @@ static if (_WIN32_WINNT >= 0x500) {
 		GUID   dbch_eventguid;
 		LONG   dbch_nameoffset;
 		BYTE   _dbch_data;
-		BYTE*  dbch_data() return scope { return &_dbch_data; }
+		BYTE*  dbch_data() return { return &_dbch_data; }
 	}
 	alias DEV_BROADCAST_HANDLE* PDEV_BROADCAST_HANDLE;
 }

--- a/source/windows/dde.d
+++ b/source/windows/dde.d
@@ -72,7 +72,7 @@ struct DDEDATA {
 	@property bool   reserved()  { return cast(bool)   (_bf & 0x4000); }
 	@property bool   fAckReq()   { return cast(bool)   (_bf & 0x8000); }
 
-	@property byte*  Value() { return &_Value; }
+	@property byte*  Value() return scope { return &_Value; }
 
 	@property ushort unused(ushort r) {
 		_bf = cast(ushort) ((_bf & ~0x0FFF) | (r & 0x0FFF));
@@ -94,7 +94,7 @@ struct DDEPOKE {
 	@property bool   fRelease()  { return cast(bool)   (_bf & 0x2000); }
 	@property ubyte  fReserved() { return cast(ubyte)  ((_bf & 0xC000) >>> 14); }
 
-	@property byte*  Value() { return &_Value; }
+	@property byte*  Value() return scope { return &_Value; }
 
 	@property ushort unused(ushort u) {
 		_bf = cast(ushort) ((_bf & ~0x1FFF) | (u & 0x1FFF));
@@ -135,7 +135,7 @@ deprecated struct DDEUP {
 	@property bool   fReserved() { return cast(bool)   (_bf & 0x4000); }
 	@property bool   fAckReq()   { return cast(bool)   (_bf & 0x8000); }
 
-	@property byte*  rgb() { return &_rgb; }
+	@property byte*  rgb() return scope { return &_rgb; }
 
 	@property ushort unused(ushort r) {
 		_bf = cast(ushort) ((_bf & ~0x0FFF) | (r & 0x0FFF));

--- a/source/windows/ddeml.d
+++ b/source/windows/ddeml.d
@@ -249,7 +249,7 @@ struct MONHSZSTRUCT {
 	HANDLE   hTask;
 	TCHAR[1] _str;
 
-	TCHAR* str() return scope { return _str.ptr; }
+	TCHAR* str() return { return _str.ptr; }
 }
 alias MONHSZSTRUCT* PMONHSZSTRUCT;
 

--- a/source/windows/ddeml.d
+++ b/source/windows/ddeml.d
@@ -249,7 +249,7 @@ struct MONHSZSTRUCT {
 	HANDLE   hTask;
 	TCHAR[1] _str;
 
-	TCHAR* str() { return _str.ptr; }
+	TCHAR* str() return scope { return _str.ptr; }
 }
 alias MONHSZSTRUCT* PMONHSZSTRUCT;
 

--- a/source/windows/ipexport.d
+++ b/source/windows/ipexport.d
@@ -95,7 +95,7 @@ struct IP_INTERFACE_INFO {
 	LONG                    NumAdapters;
 	IP_ADAPTER_INDEX_MAP[1] _Adapter;
 
-	IP_ADAPTER_INDEX_MAP* Adapter() { return _Adapter.ptr; }
+	IP_ADAPTER_INDEX_MAP* Adapter() return scope { return _Adapter.ptr; }
 }
 alias IP_INTERFACE_INFO* PIP_INTERFACE_INFO;
 
@@ -103,6 +103,6 @@ struct IP_UNIDIRECTIONAL_ADAPTER_ADDRESS {
 	ULONG     NumAdapters;
 	IPAddr[1] _Address;
 
-	IPAddr* Address() { return _Address.ptr; }
+	IPAddr* Address() return scope { return _Address.ptr; }
 }
 alias IP_UNIDIRECTIONAL_ADAPTER_ADDRESS* PIP_UNIDIRECTIONAL_ADAPTER_ADDRESS;

--- a/source/windows/iprtrmib.d
+++ b/source/windows/iprtrmib.d
@@ -69,7 +69,7 @@ struct MIB_IPADDRTABLE {
 	DWORD            dwNumEntries;
 	MIB_IPADDRROW[1] _table;
 
-	MIB_IPADDRROW* table() { return _table.ptr; }
+	MIB_IPADDRROW* table() return scope { return _table.ptr; }
 }
 alias MIB_IPADDRTABLE* PMIB_IPADDRTABLE;
 
@@ -95,7 +95,7 @@ struct MIB_IPFORWARDTABLE {
 	DWORD               dwNumEntries;
 	MIB_IPFORWARDROW[1] _table;
 
-	MIB_IPFORWARDROW* table() { return _table.ptr; }
+	MIB_IPFORWARDROW* table() return scope { return _table.ptr; }
 }
 alias MIB_IPFORWARDTABLE* PMIB_IPFORWARDTABLE;
 
@@ -112,7 +112,7 @@ struct MIB_IPNETTABLE {
 	DWORD           dwNumEntries;
 	MIB_IPNETROW[1] _table;
 
-	MIB_IPNETROW* table() { return _table.ptr; }
+	MIB_IPNETROW* table() return scope { return _table.ptr; }
 }
 alias MIB_IPNETTABLE* PMIB_IPNETTABLE;
 
@@ -176,7 +176,7 @@ struct MIB_IFTABLE {
 	DWORD        dwNumEntries;
 	MIB_IFROW[1] _table;
 
-	MIB_IFROW* table() { return _table.ptr; }
+	MIB_IFROW* table() return scope { return _table.ptr; }
 }
 alias MIB_IFTABLE* PMIB_IFTABLE;
 
@@ -239,7 +239,7 @@ struct MIB_TCPTABLE {
 	DWORD         dwNumEntries;
 	MIB_TCPROW[1] _table;
 
-	MIB_TCPROW* table() { return _table.ptr; }
+	MIB_TCPROW* table() return scope { return _table.ptr; }
 }
 alias MIB_TCPTABLE* PMIB_TCPTABLE;
 
@@ -262,6 +262,6 @@ struct MIB_UDPTABLE {
 	DWORD         dwNumEntries;
 	MIB_UDPROW[1] _table;
 
-	MIB_UDPROW* table() { return _table.ptr; }
+	MIB_UDPROW* table() return scope { return _table.ptr; }
 }
 alias MIB_UDPTABLE* PMIB_UDPTABLE;

--- a/source/windows/mcx.d
+++ b/source/windows/mcx.d
@@ -76,7 +76,7 @@ struct MODEMDEVCAPS {
 	DWORD dwMaxDCERate;
 	BYTE  _abVariablePortion;
 
-	BYTE* abVariablePortion() { return &_abVariablePortion; }
+	BYTE* abVariablePortion() return scope { return &_abVariablePortion; }
 }
 alias MODEMDEVCAPS* PMODEMDEVCAPS, LPMODEMDEVCAPS;
 
@@ -94,6 +94,6 @@ struct MODEMSETTINGS {
 	DWORD dwNegotiatedDCERate;
 	BYTE  _abVariablePortion;
 
-	BYTE* abVariablePortion() { return &_abVariablePortion; }
+	BYTE* abVariablePortion() return scope { return &_abVariablePortion; }
 }
 alias MODEMSETTINGS* PMODEMSETTINGS, LPMODEMSETTINGS;

--- a/source/windows/nspapi.d
+++ b/source/windows/nspapi.d
@@ -89,7 +89,7 @@ struct SERVICE_ADDRESSES {
 	DWORD           dwAddressCount;
 	SERVICE_ADDRESS _Addresses;
 
-	SERVICE_ADDRESS* Addresses() { return &_Addresses; }
+	SERVICE_ADDRESS* Addresses() return scope { return &_Addresses; }
 }
 alias SERVICE_ADDRESSES* PSERVICE_ADDRESSES, LPSERVICE_ADDRESSES;
 

--- a/source/windows/nspapi.d
+++ b/source/windows/nspapi.d
@@ -89,7 +89,7 @@ struct SERVICE_ADDRESSES {
 	DWORD           dwAddressCount;
 	SERVICE_ADDRESS _Addresses;
 
-	SERVICE_ADDRESS* Addresses() return scope { return &_Addresses; }
+	SERVICE_ADDRESS* Addresses() return { return &_Addresses; }
 }
 alias SERVICE_ADDRESSES* PSERVICE_ADDRESSES, LPSERVICE_ADDRESSES;
 

--- a/source/windows/ntsecapi.d
+++ b/source/windows/ntsecapi.d
@@ -452,7 +452,7 @@ struct MSV1_0_NTLM3_RESPONSE {
 	UCHAR[MSV1_0_CHALLENGE_LENGTH]      ChallengeFromClient;
 	ULONG     AvPairsOff;
 	UCHAR     _Buffer;
-	UCHAR*    Buffer() { return &_Buffer; }
+	UCHAR*    Buffer() return scope { return &_Buffer; }
 }
 alias MSV1_0_NTLM3_RESPONSE* PMSV1_0_NTLM3_RESPONSE;
 
@@ -502,7 +502,7 @@ struct MSV1_0_DERIVECRED_REQUEST {
 	ULONG  DeriveCredType;
 	ULONG  DeriveCredInfoLength;
 	UCHAR  _DeriveCredSubmitBuffer;
-	UCHAR* DeriveCredSubmitBuffer() { return &_DeriveCredSubmitBuffer; }
+	UCHAR* DeriveCredSubmitBuffer() return scope { return &_DeriveCredSubmitBuffer; }
 }
 alias MSV1_0_DERIVECRED_REQUEST* PMSV1_0_DERIVECRED_REQUEST;
 
@@ -510,7 +510,7 @@ struct MSV1_0_DERIVECRED_RESPONSE {
 	MSV1_0_PROTOCOL_MESSAGE_TYPE MessageType;
 	ULONG  DeriveCredInfoLength;
 	UCHAR  _DeriveCredReturnBuffer;
-	UCHAR* DeriveCredReturnBuffer() { return &_DeriveCredReturnBuffer; }
+	UCHAR* DeriveCredReturnBuffer() return scope { return &_DeriveCredReturnBuffer; }
 }
 alias MSV1_0_DERIVECRED_RESPONSE* PMSV1_0_DERIVECRED_RESPONSE;
 

--- a/source/windows/ole.d
+++ b/source/windows/ole.d
@@ -37,7 +37,7 @@ struct OLETARGETDEVICE {
 	USHORT otdEnvironmentOffset;
 	USHORT otdEnvironmentSize;
 	BYTE   _otdData;
-	BYTE*  otdData() { return &_otdData; }
+	BYTE*  otdData() return scope { return &_otdData; }
 }
 alias OLETARGETDEVICE* LPOLETARGETDEVICE;
 

--- a/source/windows/setupapi.d
+++ b/source/windows/setupapi.d
@@ -883,7 +883,7 @@ struct SP_INF_INFORMATION {
 	DWORD InfStyle;
 	DWORD InfCount;
 	BYTE[1] _VersionData;
-	BYTE* VersionData() { return _VersionData.ptr; }
+	BYTE* VersionData() return scope { return _VersionData.ptr; }
 }
 alias SP_INF_INFORMATION* PSP_INF_INFORMATION;
 
@@ -1040,14 +1040,14 @@ deprecated alias SP_DEVICE_INTERFACE_DATA* PSP_INTERFACE_DEVICE_DATA;
 struct SP_DEVICE_INTERFACE_DETAIL_DATA_A {
 	DWORD cbSize = SP_DEVICE_INTERFACE_DETAIL_DATA_A.sizeof;
 	CHAR[1] _DevicePath;
-	CHAR* DevicePath() { return _DevicePath.ptr; }
+	CHAR* DevicePath() return scope { return _DevicePath.ptr; }
 }
 alias SP_DEVICE_INTERFACE_DETAIL_DATA_A* PSP_DEVICE_INTERFACE_DETAIL_DATA_A;
 
 struct SP_DEVICE_INTERFACE_DETAIL_DATA_W {
 	DWORD  cbSize = SP_DEVICE_INTERFACE_DETAIL_DATA_W.sizeof;
 	WCHAR[1] _DevicePath;
-	WCHAR* DevicePath() { return _DevicePath.ptr; }
+	WCHAR* DevicePath() return scope { return _DevicePath.ptr; }
 }
 alias SP_DEVICE_INTERFACE_DETAIL_DATA_W* PSP_DEVICE_INTERFACE_DETAIL_DATA_W;
 
@@ -1303,7 +1303,7 @@ struct SP_DRVINFO_DETAIL_DATA_A {
 	CHAR[MAX_PATH] InfFileName;
 	CHAR[LINE_LEN] DrvDescription;
 	CHAR[1]        _HardwareID;
-	CHAR*          HardwareID() { return _HardwareID.ptr; }
+	CHAR*          HardwareID() return scope { return _HardwareID.ptr; }
 }
 alias SP_DRVINFO_DETAIL_DATA_A* PSP_DRVINFO_DETAIL_DATA_A;
 
@@ -1317,7 +1317,7 @@ struct SP_DRVINFO_DETAIL_DATA_W {
 	WCHAR[MAX_PATH] InfFileName;
 	WCHAR[LINE_LEN] DrvDescription;
 	WCHAR[1]        _HardwareID;
-	WCHAR*          HardwareID() { return _HardwareID.ptr; }
+	WCHAR*          HardwareID() return scope { return _HardwareID.ptr; }
 }
 alias SP_DRVINFO_DETAIL_DATA_W* PSP_DRVINFO_DETAIL_DATA_W;
 

--- a/source/windows/vfw.d
+++ b/source/windows/vfw.d
@@ -748,7 +748,7 @@ extern (Windows) {
 	void StretchDIB(LPBITMAPINFOHEADER biDst, LPVOID lpDst, int	DstX, int DstY,
 		int DstXE, int DstYE, LPBITMAPINFOHEADER biSrc, LPVOID lpSrc,
 		int SrcX, int SrcY, int SrcXE, int SrcYE);
-} 	
+}
 
 alias DWORD FOURCC;
 
@@ -832,7 +832,7 @@ struct AVIStreamHeader {
 	WORD		wPriority;
 	WORD		wLanguage;
 	DWORD		dwInitialFrames;
-	DWORD		dwScale;	
+	DWORD		dwScale;
 	DWORD		dwRate;
 	DWORD		dwStart;
 	DWORD		dwLength;
@@ -862,7 +862,7 @@ struct AVIPALCHANGE {
 	BYTE		bNumEntries;
 	WORD		wFlags;
 	PALETTEENTRY[1]	_peNew;
-	PALETTEENTRY* peNew() { return _peNew.ptr; }
+	PALETTEENTRY* peNew() return scope { return _peNew.ptr; }
 }
 
 const AVIGETFRAMEF_BESTDISPLAYFMT = 1;
@@ -930,7 +930,7 @@ struct AVIFILEINFOW {
 	DWORD	dwSuggestedBufferSize;
 	DWORD	dwWidth;
 	DWORD	dwHeight;
-	DWORD	dwScale;	
+	DWORD	dwScale;
 	DWORD	dwRate;
 	DWORD	dwLength;
 	DWORD	dwEditCount;
@@ -946,7 +946,7 @@ struct AVIFILEINFOA {
 	DWORD	dwSuggestedBufferSize;
 	DWORD	dwWidth;
 	DWORD	dwHeight;
-	DWORD	dwScale;	
+	DWORD	dwScale;
 	DWORD	dwRate;
 	DWORD	dwLength;
 	DWORD	dwEditCount;
@@ -1186,9 +1186,9 @@ STDAPI AVIFileOpenA       (PAVIFILE FAR * ppfile, LPCSTR szFile,
 STDAPI AVIFileOpenW       (PAVIFILE FAR * ppfile, LPCWSTR szFile,
 			  UINT uMode, LPCLSID lpHandler);
 #ifdef UNICODE
-#define AVIFileOpen	  AVIFileOpenW	
+#define AVIFileOpen	  AVIFileOpenW
 #else
-#define AVIFileOpen	  AVIFileOpenA	
+#define AVIFileOpen	  AVIFileOpenA
 #endif
 #else
 STDAPI AVIFileOpen       (PAVIFILE FAR * ppfile, LPCSTR szFile,

--- a/source/windows/winbase.d
+++ b/source/windows/winbase.d
@@ -202,7 +202,7 @@ struct COMMPROP {
 	DWORD dwProvSpec2;
 	WCHAR _wcProvChar;
 
-	WCHAR* wcProvChar() { return &_wcProvChar; }
+	WCHAR* wcProvChar() return scope { return &_wcProvChar; }
 }
 alias COMMPROP* LPCOMMPROP;
 
@@ -1038,7 +1038,7 @@ struct COMMCONFIG {
 	DWORD dwProviderSize;
 	WCHAR _wcProviderData;
 
-	WCHAR* wcProviderData() { return &_wcProviderData; }
+	WCHAR* wcProviderData() return scope { return &_wcProviderData; }
 }
 alias COMMCONFIG* LPCOMMCONFIG;
 
@@ -1323,7 +1323,7 @@ struct WIN32_STREAM_ID {
 	DWORD         dwStreamNameSize;
 	WCHAR         _cStreamName;
 
-	WCHAR* cStreamName() { return &_cStreamName; }
+	WCHAR* cStreamName() return scope { return &_cStreamName; }
 }
 alias WIN32_STREAM_ID* LPWIN32_STREAM_ID;
 
@@ -1533,7 +1533,7 @@ struct WIN_CERTIFICATE {
 	WORD  wCertificateType;
 	BYTE  _bCertificate;
 
-	BYTE* bCertificate() { return &_bCertificate; }
+	BYTE* bCertificate() return scope { return &_bCertificate; }
 }
 alias WIN_CERTIFICATE* LPWIN_CERTIFICATE;
 
@@ -2435,7 +2435,7 @@ WINBASEAPI BOOL WINAPI SetEvent(HANDLE);
 		BOOL SetFirmwareEnvironmentVariableW(LPCWSTR, LPCWSTR, PVOID, DWORD);
 		DWORD WTSGetActiveConsoleSessionId();
 		BOOL WTSQueryUserToken(ULONG, PHANDLE);
-		
+
 	}
 
 	// ???

--- a/source/windows/winioctl.d
+++ b/source/windows/winioctl.d
@@ -256,7 +256,7 @@ struct BIN_RESULTS {
 	DWORD     NumberOfBins;
 	BIN_COUNT _BinCounts;
 
-	BIN_COUNT* BinCounts() { return &_BinCounts; }
+	BIN_COUNT* BinCounts() return scope { return &_BinCounts; }
 }
 alias BIN_RESULTS* PBIN_RESULTS;
 
@@ -395,7 +395,7 @@ struct DISK_GEOMETRY_EX {
 	LARGE_INTEGER DiskSize;
 	BYTE          _Data;
 
-	BYTE* Data() { return &_Data; }
+	BYTE* Data() return scope { return &_Data; }
 }
 alias DISK_GEOMETRY_EX* PDISK_GEOMETRY_EX;
 
@@ -474,7 +474,7 @@ struct FORMAT_EX_PARAMETERS {
 	WORD       SectorsPerTrack;
 	WORD       _SectorNumber;
 
-	WORD* SectorNumber() { return &_SectorNumber; }
+	WORD* SectorNumber() return scope { return &_SectorNumber; }
 }
 alias FORMAT_EX_PARAMETERS* PFORMAT_EX_PARAMETERS;
 
@@ -514,7 +514,7 @@ struct VOLUME_DISK_EXTENTS {
 	DWORD       NumberOfDiskExtents;
 	DISK_EXTENT _Extents;
 
-	DISK_EXTENT* Extents() { return &_Extents; }
+	DISK_EXTENT* Extents() return scope { return &_Extents; }
 }
 alias VOLUME_DISK_EXTENTS* PVOLUME_DISK_EXTENTS;
 
@@ -535,7 +535,7 @@ struct DRIVE_LAYOUT_INFORMATION {
 	DWORD                 Signature;
 	PARTITION_INFORMATION _PartitionEntry;
 
-	PARTITION_INFORMATION* PartitionEntry() { return &_PartitionEntry; }
+	PARTITION_INFORMATION* PartitionEntry() return scope { return &_PartitionEntry; }
 }
 alias DRIVE_LAYOUT_INFORMATION* PDRIVE_LAYOUT_INFORMATION;
 
@@ -587,7 +587,7 @@ struct DRIVE_LAYOUT_INFORMATION_EX {
 	}
 	PARTITION_INFORMATION_EX _PartitionEntry;
 
-	PARTITION_INFORMATION_EX* PartitionEntry() { return &_PartitionEntry; }
+	PARTITION_INFORMATION_EX* PartitionEntry() return scope { return &_PartitionEntry; }
 }
 alias DRIVE_LAYOUT_INFORMATION_EX* PDRIVE_LAYOUT_INFORMATION_EX;
 
@@ -604,7 +604,7 @@ struct PERF_BIN {
 	DWORD     TypeOfBin;
 	BIN_RANGE _BinsRanges;
 
-	BIN_RANGE* BinsRanges() { return &_BinsRanges; }
+	BIN_RANGE* BinsRanges() return scope { return &_BinsRanges; }
 }
 alias PERF_BIN* PPERF_BIN;
 
@@ -623,7 +623,7 @@ struct RETRIEVAL_POINTERS_BUFFER {
 	}
 	Extent _Extents;
 
-	Extent* Extents() { return &_Extents; }
+	Extent* Extents() return scope { return &_Extents; }
 }
 alias RETRIEVAL_POINTERS_BUFFER* PRETRIEVAL_POINTERS_BUFFER;
 
@@ -632,7 +632,7 @@ struct REASSIGN_BLOCKS {
 	WORD  Count;
 	DWORD _BlockNumber;
 
-	DWORD* BlockNumber() { return &_BlockNumber; }
+	DWORD* BlockNumber() return scope { return &_BlockNumber; }
 }
 alias REASSIGN_BLOCKS* PREASSIGN_BLOCKS;
 
@@ -662,7 +662,7 @@ struct VOLUME_BITMAP_BUFFER {
 	LARGE_INTEGER BitmapSize;
 	BYTE          _Buffer;
 
-	BYTE* Buffer() { return &_Buffer; }
+	BYTE* Buffer() return scope { return &_Buffer; }
 }
 alias VOLUME_BITMAP_BUFFER* PVOLUME_BITMAP_BUFFER;
 

--- a/source/windows/winnt.d
+++ b/source/windows/winnt.d
@@ -2139,14 +2139,14 @@ version (X86) {
 	const INITIAL_MXCSR = 0x1f80;
 	const INITIAL_FPCSR = 0x027f;
 
-	align(16) struct M128A 
+	align(16) struct M128A
 	{
 		ULONGLONG Low;
 		LONGLONG High;
-	} 
+	}
 	alias M128A* PM128A;
 
-	struct XMM_SAVE_AREA32 
+	struct XMM_SAVE_AREA32
 	{
 		WORD ControlWord;
 		WORD StatusWord;
@@ -2164,10 +2164,10 @@ version (X86) {
 		M128A[8] FloatRegisters;
 		M128A[16] XmmRegisters;
 		BYTE[96] Reserved4;
-	} 
+	}
 	alias XMM_SAVE_AREA32 PXMM_SAVE_AREA32;
 	const LEGACY_SAVE_AREA_LENGTH = XMM_SAVE_AREA32.sizeof;
-	
+
 	align(16) struct CONTEXT
 	{
 		DWORD64 P1Home;
@@ -2208,11 +2208,11 @@ version (X86) {
 		DWORD64 R14;
 		DWORD64 R15;
 		DWORD64 Rip;
-		union 
+		union
 		{
 			XMM_SAVE_AREA32 FltSave;
 			XMM_SAVE_AREA32 FloatSave;
-			struct 
+			struct
 			{
 				M128A[2] Header;
 				M128A[8] Legacy;
@@ -2242,7 +2242,7 @@ version (X86) {
 		DWORD64 LastExceptionToRip;
 		DWORD64 LastExceptionFromRip;
 	}
-	
+
 } else {
 	static assert(false, "Unsupported CPU");
 	// Versions for PowerPC, Alpha, SHX, and MIPS removed.
@@ -2300,7 +2300,7 @@ struct PRIVILEGE_SET {
 	DWORD Control;
 	LUID_AND_ATTRIBUTES _Privilege;
 
-	LUID_AND_ATTRIBUTES* Privilege() { return &_Privilege; }
+	LUID_AND_ATTRIBUTES* Privilege() return scope { return &_Privilege; }
 }
 alias PRIVILEGE_SET* PPRIVILEGE_SET;
 
@@ -2342,7 +2342,7 @@ struct SID {
 	SID_IDENTIFIER_AUTHORITY IdentifierAuthority;
 	DWORD _SubAuthority;
 
-	DWORD* SubAuthority() { return &_SubAuthority; }
+	DWORD* SubAuthority() return scope { return &_SubAuthority; }
 }
 alias SID* PISID;
 
@@ -2375,7 +2375,7 @@ struct TOKEN_GROUPS {
 	DWORD GroupCount;
 	SID_AND_ATTRIBUTES _Groups;
 
-	SID_AND_ATTRIBUTES* Groups() { return &_Groups; }
+	SID_AND_ATTRIBUTES* Groups() return scope { return &_Groups; }
 }
 alias TOKEN_GROUPS* PTOKEN_GROUPS, LPTOKEN_GROUPS;
 
@@ -2393,7 +2393,7 @@ struct TOKEN_PRIVILEGES {
 	DWORD PrivilegeCount;
 	LUID_AND_ATTRIBUTES _Privileges;
 
-	LUID_AND_ATTRIBUTES* Privileges() { return &_Privileges; }
+	LUID_AND_ATTRIBUTES* Privileges() return scope { return &_Privileges; }
 }
 alias TOKEN_PRIVILEGES* PTOKEN_PRIVILEGES, LPTOKEN_PRIVILEGES;
 alias TOKEN_TYPE = int;
@@ -2517,7 +2517,7 @@ enum SID_NAME_USE {
 alias SID_NAME_USE* PSID_NAME_USE;
 
 alias WELL_KNOWN_SID_TYPE = int;
-enum : WELL_KNOWN_SID_TYPE { 
+enum : WELL_KNOWN_SID_TYPE {
 	WinNullSid                                   = 0,
 	WinWorldSid                                  = 1,
 	WinLocalSid                                  = 2,
@@ -2641,7 +2641,7 @@ struct FILE_NOTIFY_INFORMATION {
 	DWORD FileNameLength;
 	WCHAR _FileName;
 
-	WCHAR* FileName() { return &_FileName; }
+	WCHAR* FileName() return scope { return &_FileName; }
 }
 alias FILE_NOTIFY_INFORMATION* PFILE_NOTIFY_INFORMATION;
 
@@ -2741,7 +2741,7 @@ struct MESSAGE_RESOURCE_ENTRY {
 	WORD Flags;
 	BYTE _Text;
 
-	BYTE* Text() { return &_Text; }
+	BYTE* Text() return scope { return &_Text; }
 }
 alias MESSAGE_RESOURCE_ENTRY* PMESSAGE_RESOURCE_ENTRY;
 
@@ -2756,7 +2756,7 @@ struct MESSAGE_RESOURCE_DATA {
 	DWORD NumberOfBlocks;
 	MESSAGE_RESOURCE_BLOCK _Blocks;
 
-	MESSAGE_RESOURCE_BLOCK* Blocks() { return &_Blocks; }
+	MESSAGE_RESOURCE_BLOCK* Blocks() return scope { return &_Blocks; }
 }
 alias MESSAGE_RESOURCE_DATA* PMESSAGE_RESOURCE_DATA;
 
@@ -3259,7 +3259,7 @@ struct IMAGE_IMPORT_BY_NAME {
 	WORD Hint;
 	BYTE _Name;
 
-	BYTE* Name() {
+	BYTE* Name() return scope {
 		return &_Name;
 	}
 }
@@ -3387,7 +3387,7 @@ struct IMAGE_RESOURCE_DIRECTORY_STRING {
 	WORD Length;
 	CHAR _NameString;
 
-	CHAR* NameString() { return &_NameString; }
+	CHAR* NameString() return scope { return &_NameString; }
 }
 alias IMAGE_RESOURCE_DIRECTORY_STRING* PIMAGE_RESOURCE_DIRECTORY_STRING;
 
@@ -3395,7 +3395,7 @@ struct IMAGE_RESOURCE_DIR_STRING_U {
 	WORD  Length;
 	WCHAR _NameString;
 
-	WCHAR* NameString() { return &_NameString; }
+	WCHAR* NameString() return scope { return &_NameString; }
 }
 alias IMAGE_RESOURCE_DIR_STRING_U* PIMAGE_RESOURCE_DIR_STRING_U;
 
@@ -3540,7 +3540,7 @@ struct IMAGE_DEBUG_MISC {
 	BYTE[3] Reserved;
 	BYTE    _Data;
 
-	BYTE*   Data() { return &_Data; }
+	BYTE*   Data() return scope { return &_Data; }
 }
 alias IMAGE_DEBUG_MISC* PIMAGE_DEBUG_MISC;
 
@@ -3630,7 +3630,7 @@ struct REPARSE_DATA_BUFFER {
 		struct _GenericReparseBuffer {
 			BYTE  _DataBuffer;
 
-			BYTE* DataBuffer() { return &_DataBuffer; }
+			BYTE* DataBuffer() return scope { return &_DataBuffer; }
 		}
 		_GenericReparseBuffer GenericReparseBuffer;
 		struct _SymbolicLinkReparseBuffer {
@@ -3642,7 +3642,7 @@ struct REPARSE_DATA_BUFFER {
 			ULONG Flags;
 			WCHAR _PathBuffer;
 
-			WCHAR* PathBuffer() { return &_PathBuffer; }
+			WCHAR* PathBuffer() return scope { return &_PathBuffer; }
 		}
 		_SymbolicLinkReparseBuffer SymbolicLinkReparseBuffer;
 		struct _MountPointReparseBuffer {
@@ -3652,7 +3652,7 @@ struct REPARSE_DATA_BUFFER {
 			WORD  PrintNameLength;
 			WCHAR _PathBuffer;
 
-			WCHAR* PathBuffer() { return &_PathBuffer; }
+			WCHAR* PathBuffer() return scope { return &_PathBuffer; }
 		}
 		_MountPointReparseBuffer MountPointReparseBuffer;
 	}
@@ -3667,7 +3667,7 @@ struct REPARSE_GUID_DATA_BUFFER {
 	struct _GenericReparseBuffer {
 		BYTE _DataBuffer;
 
-		BYTE* DataBuffer() { return &_DataBuffer; }
+		BYTE* DataBuffer() return scope { return &_DataBuffer; }
 	}
 	_GenericReparseBuffer GenericReparseBuffer;
 }
@@ -3787,7 +3787,7 @@ struct JOBOBJECT_BASIC_PROCESS_ID_LIST {
 	DWORD     NumberOfProcessIdsInList;
 	ULONG_PTR _ProcessIdList;
 
-	ULONG_PTR* ProcessIdList() { return &_ProcessIdList; }
+	ULONG_PTR* ProcessIdList() return scope { return &_ProcessIdList; }
 }
 alias JOBOBJECT_BASIC_PROCESS_ID_LIST* PJOBOBJECT_BASIC_PROCESS_ID_LIST;
 

--- a/source/windows/winnt.d
+++ b/source/windows/winnt.d
@@ -2375,7 +2375,7 @@ struct TOKEN_GROUPS {
 	DWORD GroupCount;
 	SID_AND_ATTRIBUTES _Groups;
 
-	SID_AND_ATTRIBUTES* Groups() return scope { return &_Groups; }
+	SID_AND_ATTRIBUTES* Groups() return { return &_Groups; }
 }
 alias TOKEN_GROUPS* PTOKEN_GROUPS, LPTOKEN_GROUPS;
 

--- a/source/windows/winsock2.d
+++ b/source/windows/winsock2.d
@@ -933,7 +933,7 @@ alias CSADDR_INFO* PCSADDR_INFO, LPCSADDR_INFO;
 struct SOCKET_ADDRESS_LIST {
     INT               iAddressCount;
     SOCKET_ADDRESS[1] _Address;
-    SOCKET_ADDRESS* Address() return scope { return _Address.ptr; }
+    SOCKET_ADDRESS* Address() return { return _Address.ptr; }
 }
 
 alias SOCKET_ADDRESS_LIST* LPSOCKET_ADDRESS_LIST;

--- a/source/windows/winsock2.d
+++ b/source/windows/winsock2.d
@@ -933,7 +933,7 @@ alias CSADDR_INFO* PCSADDR_INFO, LPCSADDR_INFO;
 struct SOCKET_ADDRESS_LIST {
     INT               iAddressCount;
     SOCKET_ADDRESS[1] _Address;
-    SOCKET_ADDRESS* Address() { return _Address.ptr; }
+    SOCKET_ADDRESS* Address() return scope { return _Address.ptr; }
 }
 
 alias SOCKET_ADDRESS_LIST* LPSOCKET_ADDRESS_LIST;


### PR DESCRIPTION
This is #10 plus converting these `return scope` to `scope`, to silence new deprecations like
```
windows-headers\source\windows\dbt.d(186): Deprecation: returning `&this._dbch_data` escapes a reference to parameter `this`
windows-headers\source\windows\dbt.d(186):        perhaps remove `scope` parameter annotation so `return` applies to `ref`
```